### PR TITLE
Fixed bug caused by change to htslib

### DIFF
--- a/src/i2b.c
+++ b/src/i2b.c
@@ -1390,7 +1390,7 @@ static bam1_t *makeRecord(int flags, opts_t *opts, char *readName,
 
     int r = bam_construct_seq(&bam, 0, readName, strlen(readName),
                                 flags, -1, 0, 0, 0, 0, (uint32_t*)"", -1, 0, 0, strlen(bases), bases, qualities);
-    if (r) {
+    if (r < 0) {
         fprintf(stderr,"bam_construct_seq() failed\n");
         exit(1);
     }


### PR DESCRIPTION
This change is required because bam_construct_seq() in cram/cram_samtools.c has changed it's return value.