### PR TITLE
Avoid hard-coded include paths and use the flags created by the htslib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 ACLOCAL_AMFLAGS= -I m4
 
-AM_CPPFLAGS = $(HTSLIB_CPPFLAGS) -std=gnu99 -Werror
+AM_CPPFLAGS = -I$(top_srcdir)/src $(HTSLIB_CPPFLAGS) -std=gnu99 -Werror
+AM_CFLAGS = $(XML_CFLAGS) -std=gnu99 -Werror
 AM_LDFLAGS = -rdynamic $(HTSLIB_LDFLAGS)
 
 bin_PROGRAMS = src/bambi
@@ -34,8 +35,8 @@ src_bambi_SOURCES = src/bambi.c \
                     src/parse_bam.h
 
 nobase_include_HEADERS = src/cram/cram_samtools.h src/cram/pooled_alloc.h src/cram/sam_header.h src/cram/string_alloc.h
-src_bambi_CFLAGS = -I/usr/include/libxml2 -I$(top_srcdir)/src
-src_bambi_LDADD = $(HTSLIB_HOME)/lib/libhts.a -ldl -lxml2 -lz -llzma -lbz2 -lpthread -lcurl -lcrypto -lgd -lm
+
+src_bambi_LDADD = $(HTSLIB_LIBS) -lm
 
 TESTS = test/t_array \
         test/t_bamit \
@@ -63,8 +64,8 @@ check_PROGRAMS = test/t_read2tags \
                  test/t_i2b \
                  test/t_sf
 
-TEST_CFLAGS = -I$(top_srcdir)/src -I/usr/include/libxml2 -DDATA_DIR=$(top_srcdir)/test/data
-TEST_LDADD = $(HTSLIB_HOME)/lib/libhts.a -lz -ldl -lxml2 -lpthread -llzma -lbz2 -lcurl -lcrypto
+TEST_CFLAGS = -I$(top_srcdir)/src $(XML_CFLAGS) -DDATA_DIR=$(top_srcdir)/test/data
+TEST_LDADD = $(HTSLIB_LIBS) -lm
 
 test_t_read2tags_SOURCES = test/t_read2tags.c src/read2tags.c src/array.c src/bamit.c src/parse.c src/hts_addendum.c
 test_t_read2tags_CFLAGS = $(TEST_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -18,8 +18,14 @@ LDFLAGS="$HTSLIB_LDFLAGS"
 AC_CHECK_HEADERS([cram/sam_header.h])
 AC_CHECK_LIB([hts], [bam_aux_update_str], [AC_DEFINE([HAVE_BAM_AUX_UPDATE_STR],[1],[Does htslib contain bam_aux_update_str()?])])
 AC_CHECK_LIB([hts], [sam_hdr_del], [AC_DEFINE([HAVE_SAM_HDR_DEL],[1],[Does htslib contain sam_hdr_del()?])])
+PKG_CHECK_MODULES(XML, libxml-2.0 >= 2.7)
 CPPFLAGS="$saved_CPPFLAGS"
 LDFLAGS="$saved_LDFLAGS"
+
+AC_CHECK_LIB([xml2], [xmlParseFile])
+AC_CHECK_LIB([gd], [gdImageCreate])
+
+AC_CONFIG_SRCDIR([src/bambi.h])
 
 AC_CONFIG_FILES([ Makefile ])
 AC_OUTPUT


### PR DESCRIPTION
macro.