### PR TITLE
Posix_fadvise experiment

### DIFF
--- a/src/bclfile.h
+++ b/src/bclfile.h
@@ -72,9 +72,9 @@ typedef struct {
 } bclfile_t;
 
 int bcl_tile2surface(int tile);
-bclfile_t *bclfile_open(char *fname, MACHINE_TYPE mt);
+bclfile_t *bclfile_open(char *fname, MACHINE_TYPE mt, int tile);
 void bclfile_close(bclfile_t *bclfile);
-int bclfile_load_tile(bclfile_t *bclfile, int tile, filter_t *filter);
+int bclfile_load_tile(bclfile_t *bclfile, int tile, filter_t *filter, int next_tile);
 char bclfile_base(bclfile_t *bcl, int cluster);
 int bclfile_quality(bclfile_t *bcl, int cluster);
 #endif

--- a/test/t_bclfile.c
+++ b/test/t_bclfile.c
@@ -93,7 +93,7 @@ int main(int argc, char**argv)
 
     // BCL tests
 
-    bclfile = bclfile_open(MKNAME(DATA_DIR,"/s_1_1101.bcl.gz"), MT_HISEQX);
+    bclfile = bclfile_open(MKNAME(DATA_DIR,"/s_1_1101.bcl.gz"), MT_HISEQX, -1);
     if (bclfile->errmsg) {
         fprintf(stderr,"Error opening file: %s\n", bclfile->errmsg);
         failure++;
@@ -111,12 +111,12 @@ int main(int argc, char**argv)
 
     // CBCL tests
 
-    bclfile = bclfile_open(MKNAME(DATA_DIR,"/novaseq/Data/Intensities/BaseCalls/L001/C1.1/L001_1.cbcl"), MT_NOVASEQ);
+    bclfile = bclfile_open(MKNAME(DATA_DIR,"/novaseq/Data/Intensities/BaseCalls/L001/C1.1/L001_1.cbcl"), MT_NOVASEQ, 1101);
     if (bclfile->errmsg) {
         fprintf(stderr,"Error opening file: %s\n", bclfile->errmsg);
         failure++;
     }
-    bclfile_load_tile(bclfile,1101,NULL);
+    bclfile_load_tile(bclfile,1101,NULL,-1);
     icheckEqual("machine type", MT_NOVASEQ, bclfile->machine_type);
     icheckEqual("version", 1, bclfile->version);
     icheckEqual("header_size", 65, bclfile->header_size);


### PR DESCRIPTION
Try to use posix_fadvise() on NovaSeq cbcl files to pre-cache the next tile while processing the current one, which should speed up reads.  It can also flush out the data for the current tile after it's been consumed on the assumption that we won't read it again so it doesn't need to hang around.

This needs testing on full sized data sets to see if it has any significant benefit.  At the moment the default is to both pre-cache the next tile and flush the completed ones.  This can be changed by defining `USE_POSIX_FADVISE`:
```
make CPPFLAGS=-DUSE_POSIX_FADVISE=0  # Disable posix_fadvise()
make CPPFLAGS=-DUSE_POSIX_FADVISE=1  # Pre-cache only
make CPPFLAGS=-DUSE_POSIX_FADVISE=2  # Flush only (unlikely to be useful)
make CPPFLAGS=-DUSE_POSIX_FADVISE=3  # Pre-cache and flush (current default)
```