### PR TITLE
Make BAMit and decode multi-threaded

### DIFF
--- a/src/bamit.c
+++ b/src/bamit.c
@@ -42,7 +42,8 @@ BAMit_t *BAMit_init(samFile *f, bam_hdr_t *h)
  *                char *fmt                 format [bam,sam,cram]
  *                char compression level    [0..9]
  */
-BAMit_t *BAMit_open(char *fname, char mode, char *fmt, char compression_level)
+BAMit_t *BAMit_open(char *fname, char mode, char *fmt, char compression_level,
+                    htsThreadPool *thread_pool)
 {
     samFile *f = NULL;
     bam_hdr_t *h = NULL;
@@ -62,6 +63,11 @@ BAMit_t *BAMit_open(char *fname, char mode, char *fmt, char compression_level)
     free(format);
     if (!f) {
         fprintf(stderr,"Could not open file (%s)\n", fname);
+        exit(1);
+    }
+
+    if (thread_pool && hts_set_thread_pool(f, thread_pool) < 0) {
+        fprintf(stderr, "Couldn't set thread pool on %s\n", fname);
         exit(1);
     }
 

--- a/src/bamit.h
+++ b/src/bamit.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 #include <stdlib.h>
 #include "htslib/sam.h"
+#include "htslib/hts.h"
 
 /*
  * iterator structure
@@ -36,12 +37,14 @@ typedef struct {
 
 /*
  * Open a BAM file
- * arguments are: char *fname               filename to open
- *                char mode                 'r' or 'w'
- *                char *fmt                 format [bam,sam,cram] or NULL
- *                char compression level    [0..9] or NULL
+ * arguments are: char *fname                filename to open
+ *                char mode                  'r' or 'w'
+ *                char *fmt                  format [bam,sam,cram] or NULL
+ *                char compression level     [0..9] or NULL
+ *                htsThreadPool *thread_pool thread pool to use, or NULL
  */
-BAMit_t *BAMit_open(char *fname, char mode, char *fmt, char compression_level);
+BAMit_t *BAMit_open(char *fname, char mode, char *fmt, char compression_level,
+                    htsThreadPool *thread_pool);
 
 /*
  * initialise with open file pointer and header

--- a/src/decode.c
+++ b/src/decode.c
@@ -693,7 +693,7 @@ static int noCalls(char *s)
 static int countMismatches(char *tag, char *barcode, int maxval)
 {
     int n = 0;
-    for (int i=0; tag[i]; i++) {
+    for (int i=0; tag[i] && barcode[i]; i++) {
         if ((tag[i] != barcode[i]) && (barcode[i] != 'N')) {
             n++;
             if (n>maxval) return n;     // exit early if we can

--- a/src/read2tags.c
+++ b/src/read2tags.c
@@ -736,8 +736,8 @@ int process(opts_t* opts)
     int nrec = 0;
     int r;
 
-    BAMit_t *bam_in = BAMit_open(opts->in_file, 'r', opts->input_fmt, 0);
-    BAMit_t *bam_out = BAMit_open(opts->out_file, 'w', opts->output_fmt, opts->compression_level);
+    BAMit_t *bam_in = BAMit_open(opts->in_file, 'r', opts->input_fmt, 0, NULL);
+    BAMit_t *bam_out = BAMit_open(opts->out_file, 'w', opts->output_fmt, opts->compression_level, NULL);
 
     // copy input to output header
     bam_hdr_destroy(bam_out->h); bam_out->h = bam_hdr_dup(bam_in->h);

--- a/src/spatial_filter.c
+++ b/src/spatial_filter.c
@@ -1373,7 +1373,7 @@ static void calculateFilter(opts_t *opts)
 
 	RegionTable ***rts = NULL;
     
-	fp_input_bam = BAMit_open(opts->in_bam_file, 'r', opts->input_fmt, 0);
+	fp_input_bam = BAMit_open(opts->in_bam_file, 'r', opts->input_fmt, 0, NULL);
 	if (NULL == fp_input_bam) {
 		die("ERROR: can't open bam file %s: %s\n", opts->in_bam_file, strerror(errno));
 	}
@@ -1461,13 +1461,13 @@ static void applyFilter(opts_t *s)
     }
     strcat(apply_stats_file, s->apply_stats_out);
 
-	fp_input_bam = BAMit_open(s->in_bam_file, 'r', s->input_fmt, 0);
+	fp_input_bam = BAMit_open(s->in_bam_file, 'r', s->input_fmt, 0, NULL);
 	if (NULL == fp_input_bam) {
 		die("ERROR: can't open bam file %s: %s\n", s->in_bam_file, strerror(errno));
 	}
 
 
-	fp_output_bam = BAMit_open(out_bam_file, 'w', s->output_fmt, s->compression_level);
+	fp_output_bam = BAMit_open(out_bam_file, 'w', s->output_fmt, s->compression_level, NULL);
 	if (NULL == fp_output_bam) {
 		die("ERROR: can't open bam file %s: %s\n", out_bam_file, strerror(errno));
 	}

--- a/test/t_bamit.c
+++ b/test/t_bamit.c
@@ -107,12 +107,12 @@ int main(int argc, char**argv)
     icheckEqual("End of records", false, BAMit_hasnext(bit));
     BAMit_free(bit);
 
-    bit = BAMit_open(MKNAME(DATA_DIR,"/bamit.bam"), 'r', NULL, 0);
+    bit = BAMit_open(MKNAME(DATA_DIR,"/bamit.bam"), 'r', NULL, 0, NULL);
     rec = BAMit_next(bit);
     checkEqual("First name", "IL16_986:1:9:9:307", bam_get_qname(rec));
     BAMit_free(bit);
 
-    bit = BAMit_open(MKNAME(DATA_DIR,"/bamit_empty.bam"), 'r', NULL, 0);
+    bit = BAMit_open(MKNAME(DATA_DIR,"/bamit_empty.bam"), 'r', NULL, 0, NULL);
     icheckEqual("Empty bam file", false, BAMit_hasnext(bit));
     BAMit_free(bit);
 

--- a/test/t_decode.c
+++ b/test/t_decode.c
@@ -28,6 +28,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define xMKNAME(d,f) #d f
 #define MKNAME(d,f) xMKNAME(d,f)
 
+#define NTHREADS 4
+
 const char * bambi_version(void)
 {
     return "12.34";
@@ -47,9 +49,19 @@ void die(const char *fmt, ...)
 int success = 0;
 int failure = 0;
 
-void setup_test_1(int* argc, char*** argv, char *outputfile, char *metricsfile)
+static char *itoa(int i)
 {
-    *argc = 16;
+    const size_t sz = 32;
+    char *a = malloc(sz);
+    if (!a) die("Out of memory");
+    snprintf(a, sz, "%d", i);
+    return a;
+}
+
+void setup_test_1(int* argc, char*** argv, char *outputfile, char *metricsfile,
+                  int threads)
+{
+    *argc = 16 + (threads ? 2 : 0);
     *argv = (char**)calloc(sizeof(char*), *argc);
     (*argv)[0] = strdup("bambi");
     (*argv)[1] = strdup("decode");
@@ -67,11 +79,16 @@ void setup_test_1(int* argc, char*** argv, char *outputfile, char *metricsfile)
     (*argv)[13] = strdup(metricsfile);
     (*argv)[14] = strdup("--barcode-tag-name");
     (*argv)[15] = strdup("RT");
+    if (threads) {
+        (*argv)[16] = strdup("-t");
+        (*argv)[17] = itoa(threads);
+    }
 }
 
-void setup_test_2(int* argc, char*** argv, char *outputfile, char *metricsfile)
+void setup_test_2(int* argc, char*** argv, char *outputfile, char *metricsfile,
+                  int threads)
 {
-    *argc = 18;
+    *argc = 18 + (threads ? 2 : 0);
     *argv = (char**)calloc(sizeof(char*), *argc);
     (*argv)[0] = strdup("bambi");
     (*argv)[1] = strdup("decode");
@@ -91,11 +108,16 @@ void setup_test_2(int* argc, char*** argv, char *outputfile, char *metricsfile)
     (*argv)[15] = strdup(metricsfile);
     (*argv)[16] = strdup("--barcode-tag-name");
     (*argv)[17] = strdup("RT");
+    if (threads) {
+        (*argv)[18] = strdup("-t");
+        (*argv)[19] = itoa(threads);
+    }
 }
 
-void setup_test_3(int* argc, char*** argv, char *outputfile, char *metricsfile)
+void setup_test_3(int* argc, char*** argv, char *outputfile, char *metricsfile,
+                  int threads)
 {
-    *argc = 15;
+    *argc = 15 + (threads ? 2 : 0);
     *argv = (char**)calloc(sizeof(char*), *argc);
     (*argv)[0] = strdup("bambi");
     (*argv)[1] = strdup("decode");
@@ -112,11 +134,16 @@ void setup_test_3(int* argc, char*** argv, char *outputfile, char *metricsfile)
     (*argv)[12] = strdup("--convert-low-quality");
     (*argv)[13] = strdup("--max-no-calls");
     (*argv)[14] = strdup("6");
+    if (threads) {
+        (*argv)[15] = strdup("--threads");
+        (*argv)[16] = itoa(threads);
+    }
 }
 
-void setup_test_4(int* argc, char*** argv, char *outputfile, char* metricsfile)
+void setup_test_4(int* argc, char*** argv, char *outputfile, char* metricsfile,
+                  int threads)
 {
-    *argc = 15;
+    *argc = 15 + (threads ? 2 : 0);
     *argv = (char**)calloc(sizeof(char*), *argc);
     (*argv)[0] = strdup("bambi");
     (*argv)[1] = strdup("decode");
@@ -133,6 +160,10 @@ void setup_test_4(int* argc, char*** argv, char *outputfile, char* metricsfile)
     (*argv)[12] = strdup("--metrics-file");
     (*argv)[13] = strdup(metricsfile);
     (*argv)[14] = strdup("--ignore-pf");
+    if (threads) {
+        (*argv)[15] = strdup("--threads");
+        (*argv)[16] = itoa(threads);
+    }
 }
 
 void free_argv(int argc, char *argv[])
@@ -217,110 +248,123 @@ int main(int argc, char**argv)
     unsigned int max_path_length = strlen(TMPDIR) + 100;
     char *outputfile = calloc(1,max_path_length);
     char *metricsfile = calloc(1,max_path_length);
+    char cmd[1024];
     
     // minimal options
-    int argc_1;
-    char** argv_1;
-    sprintf(outputfile,"%s/decode_1.sam", TMPDIR);
-    snprintf(metricsfile, max_path_length, "%s/decode_1.metrics", TMPDIR);
-    setup_test_1(&argc_1, &argv_1, outputfile, metricsfile);
-    main_decode(argc_1-1, argv_1+1);
-    free_argv(argc_1,argv_1);
 
-    char *cmd = calloc(1,1024);
-    sprintf(cmd,"diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/6383_9_nosplit_nochange.sam"));
-    int result = system(cmd);
-    if (result) {
-        fprintf(stderr, "test 1 failed\n");
-        failure++;
-    } else {
-        success++;
-    }
+    for (int threads = 0; threads <= NTHREADS; threads+=NTHREADS) {
+        int argc_1;
+        char** argv_1;
+        int result;
 
-    sprintf(cmd,"diff -I ID:bambi %s %s", metricsfile, MKNAME(DATA_DIR,"/out/decode_1.metrics"));
-    result = system(cmd);
-    if (result) {
-        fprintf(stderr, "test 1 failed at metrics file diff\n");
-        failure++;
-    } else {
-        success++;
+        snprintf(outputfile, max_path_length, "%s/decode_1%s.sam", TMPDIR, threads ? "threads" : "");
+        snprintf(metricsfile, max_path_length, "%s/decode_1%s.metrics", TMPDIR, threads ? "threads" : "");
+        setup_test_1(&argc_1, &argv_1, outputfile, metricsfile, threads);
+        main_decode(argc_1-1, argv_1+1);
+        free_argv(argc_1,argv_1);
+
+        snprintf(cmd, sizeof(cmd), "diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/6383_9_nosplit_nochange.sam"));
+        result = system(cmd);
+        if (result) {
+            fprintf(stderr, "test 1 failed\n");
+            failure++;
+        } else {
+            success++;
+        }
+
+        snprintf(cmd, sizeof(cmd), "diff -I ID:bambi %s %s", metricsfile, MKNAME(DATA_DIR,"/out/decode_1.metrics"));
+        result = system(cmd);
+        if (result) {
+            fprintf(stderr, "test 1 failed at metrics file diff\n");
+            failure++;
+        } else {
+            success++;
+        }
     }
 
     // --convert_low_quality option
-    int argc_2;
-    char** argv_2;
-    sprintf(outputfile,"%s/decode_2.sam",TMPDIR);
-    snprintf(metricsfile, max_path_length, "%s/decode_2.metrics", TMPDIR);
-    setup_test_2(&argc_2, &argv_2, outputfile, metricsfile);
-    main_decode(argc_2-1, argv_2+1);
-    free_argv(argc_2,argv_2);
+    for (int threads = 0; threads <= NTHREADS; threads += NTHREADS) {
+        int argc_2;
+        char** argv_2;
+        int result;
+        snprintf(outputfile, max_path_length, "%s/decode_2%s.sam", TMPDIR, threads ? "threads" : "");
+        snprintf(metricsfile, max_path_length, "%s/decode_2%s.metrics", TMPDIR, threads ? "threads" : "");
+        setup_test_2(&argc_2, &argv_2, outputfile, metricsfile, threads);
+        main_decode(argc_2-1, argv_2+1);
+        free_argv(argc_2,argv_2);
 
-    sprintf(cmd,"diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/6383_8_nosplitN.sam"));
-    result = system(cmd);
-    if (result) {
-        fprintf(stderr, "test 2 failed\n");
-        failure++;
-    } else {
-        success++;
+        snprintf(cmd, sizeof(cmd), "diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/6383_8_nosplitN.sam"));
+        result = system(cmd);
+        if (result) {
+            fprintf(stderr, "test 2 failed\n");
+            failure++;
+        } else {
+            success++;
+        }
     }
 
     // check for handling low quality paired reads
-    int argc_3;
-    char** argv_3;
-    sprintf(outputfile,"%s/decode_3.sam",TMPDIR);
-    snprintf(metricsfile, max_path_length, "%s/decode_3.metrics", TMPDIR);
-    setup_test_3(&argc_3, &argv_3, outputfile, metricsfile);
-    main_decode(argc_3-1, argv_3+1);
-    free_argv(argc_3,argv_3);
+    for (int threads = 0; threads <= NTHREADS; threads += NTHREADS) {
+        int argc_3;
+        char** argv_3;
+        int result;
+        snprintf(outputfile, max_path_length, "%s/decode_3%s.sam", TMPDIR, threads ? "threads" : "");
+        snprintf(metricsfile, max_path_length, "%s/decode_3%s.metrics", TMPDIR, threads ? "threads" : "");
+        setup_test_3(&argc_3, &argv_3, outputfile, metricsfile, threads);
+        main_decode(argc_3-1, argv_3+1);
+        free_argv(argc_3,argv_3);
 
-    sprintf(cmd,"diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/decode_3.sam"));
-    result = system(cmd);
-    if (result) {
-        fprintf(stderr, "test 3 failed\n");
-        failure++;
-    } else {
-        success++;
+        snprintf(cmd, sizeof(cmd), "diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/decode_3.sam"));
+        result = system(cmd);
+        if (result) {
+            fprintf(stderr, "test 3 failed\n");
+            failure++;
+        } else {
+            success++;
+        }
     }
 
     // --dual-tag option
-    int argc_4;
-    char** argv_4;
-    sprintf(outputfile,"%s/decode_4.sam",TMPDIR);
-    snprintf(metricsfile, max_path_length, "%s/decode_4.metrics", TMPDIR);
-    setup_test_4(&argc_4, &argv_4, outputfile, metricsfile);
-    main_decode(argc_4-1, argv_4+1);
-    free_argv(argc_4,argv_4);
+    for (int threads = 0; threads <= NTHREADS; threads += NTHREADS) {
+        int argc_4;
+        char** argv_4;
+        int result;
+        snprintf(outputfile, max_path_length,"%s/decode_4%s.sam",TMPDIR, threads ? "threads" : "");
+        snprintf(metricsfile, max_path_length, "%s/decode_4%s.metrics", TMPDIR, threads ? "threads" : "");
+        setup_test_4(&argc_4, &argv_4, outputfile, metricsfile, threads);
+        main_decode(argc_4-1, argv_4+1);
+        free_argv(argc_4,argv_4);
 
-    sprintf(cmd,"diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/decode_4.sam"));
-    result = system(cmd);
-    if (result) {
-        fprintf(stderr, "test 4 failed at SAM file diff\n");
-        failure++;
-    } else {
-        success++;
-    }
+        snprintf(cmd, sizeof(cmd), "diff -I ID:bambi %s %s", outputfile, MKNAME(DATA_DIR,"/out/decode_4.sam"));
+        result = system(cmd);
+        if (result) {
+            fprintf(stderr, "test 4 failed at SAM file diff\n");
+            failure++;
+        } else {
+            success++;
+        }
 
-    sprintf(cmd,"diff -I ID:bambi %s %s", metricsfile, MKNAME(DATA_DIR,"/out/decode_4.metrics"));
-    result = system(cmd);
-    if (result) {
-        fprintf(stderr, "test 4 failed at metrics file diff\n");
-        failure++;
-    } else {
-        success++;
-    }
+        snprintf(cmd, sizeof(cmd), "diff -I ID:bambi %s %s", metricsfile, MKNAME(DATA_DIR,"/out/decode_4.metrics"));
+        result = system(cmd);
+        if (result) {
+            fprintf(stderr, "test 4 failed at metrics file diff\n");
+            failure++;
+        } else {
+            success++;
+        }
 
-    sprintf(cmd,"diff -I ID:bambi %s %s", strcat(metricsfile, ".hops"), MKNAME(DATA_DIR,"/out/decode_4.metrics.hops"));
-    result = system(cmd);
-    if (result) {
-        fprintf(stderr, "test 4 failed at tag hops file diff\n");
-        failure++;
-    } else {
-        success++;
+        snprintf(cmd, sizeof(cmd), "diff -I ID:bambi %s %s", strcat(metricsfile, ".hops"), MKNAME(DATA_DIR,"/out/decode_4.metrics.hops"));
+        result = system(cmd);
+        if (result) {
+            fprintf(stderr, "test 4 failed at tag hops file diff\n");
+            failure++;
+        } else {
+            success++;
+        }
     }
 
     free(metricsfile);
     free(outputfile);
-    free(cmd);
 
     printf("decode tests: %s\n", failure ? "FAILED" : "Passed");
     return failure ? EXIT_FAILURE : EXIT_SUCCESS;


### PR DESCRIPTION
Allow an htsThreadPool parameter to be passed into BAMit_open, to enable threading when reading/writing the file.

Add a -t/--threads option to decode

Make decode batch up work and run it through the thread pool.  The thread jobs have their own copies of the metrics data structures to avoid having to lock them when updating counts.  The metrics are all added up when all of the jobs have finished.  They also recycle memory between jobs as much as possible to reduce the amount of time spent in malloc/free.

Use buffers on the stack in a number of cases where small memory allocations are short-lived, falling back to using malloc where the memory needed is bigger than the fixed-size buffer.  This gives a small speed gain, although only about 10% in my tests.