### PR TITLE
Make builds use -Wall -Werror; fix resulting warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,8 @@ AM_LDFLAGS = -rdynamic $(HTSLIB_LDFLAGS)
 bin_PROGRAMS = src/bambi
 src_bambi_SOURCES = src/bambi.c \
                     src/bambi.h \
+                    src/bambi_utils.c \
+                    src/bambi_utils.h \
                     src/decode.c \
                     src/i2b.c \
                     src/select.c \
@@ -67,7 +69,7 @@ check_PROGRAMS = test/t_read2tags \
 TEST_CFLAGS = -I$(top_srcdir)/src $(XML_CFLAGS) -DDATA_DIR=$(top_srcdir)/test/data
 TEST_LDADD = $(HTSLIB_LIBS) -lm
 
-test_t_read2tags_SOURCES = test/t_read2tags.c src/read2tags.c src/array.c src/bamit.c src/parse.c src/hts_addendum.c
+test_t_read2tags_SOURCES = test/t_read2tags.c src/read2tags.c src/array.c src/bamit.c src/parse.c src/hts_addendum.c src/bambi_utils.c
 test_t_read2tags_CFLAGS = $(TEST_CFLAGS)
 test_t_read2tags_LDADD = $(TEST_LDADD)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS= -I m4
 
-AM_CPPFLAGS = -I$(top_srcdir)/src $(HTSLIB_CPPFLAGS) -std=gnu99 -Werror
-AM_CFLAGS = $(XML_CFLAGS) -std=gnu99 -Werror
+AM_CPPFLAGS = -I$(top_srcdir)/src $(HTSLIB_CPPFLAGS) -std=gnu99
+AM_CFLAGS = $(XML_CFLAGS) -std=gnu99
 AM_LDFLAGS = -rdynamic $(HTSLIB_LDFLAGS)
 
 bin_PROGRAMS = src/bambi

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,16 @@
 AC_INIT([bambi], m4_esyscmd_s([git describe --dirty --always --tags]), [js10@sanger.ac.uk])
+AC_CONFIG_MACRO_DIR([m4])
 AC_ARG_VAR(HTSDIR,Directory to look for hts)
-AM_INIT_AUTOMAKE([subdir-objects -Wall -Werror foreign tar-pax no-dependencies])
+AM_INIT_AUTOMAKE([subdir-objects foreign tar-pax no-dependencies])
+
 AC_PROG_CC
+dnl Turn on compiler warnings, if possible
+HTS_PROG_CC_WARNINGS
+dnl Flags to treat warnings as errors.  These need to be applied to CFLAGS
+dnl later as they can interfere with some of the tests (notably AC_SEARCH_LIBS)
+HTS_PROG_CC_WERROR(bambi_late_cflags)
 
 LT_INIT
-
-AC_CONFIG_MACRO_DIR([m4])
 
 AX_WITH_HTSLIB
 
@@ -26,6 +31,9 @@ AC_CHECK_LIB([xml2], [xmlParseFile])
 AC_CHECK_LIB([gd], [gdImageCreate])
 
 AC_CONFIG_SRCDIR([src/bambi.h])
+
+dnl Apply value from HTS_PROG_CC_WERROR (if set)
+AS_IF([test "x$bambi_late_cflags" != x],[CFLAGS="$CFLAGS $bambi_late_cflags"])
 
 AC_CONFIG_FILES([ Makefile ])
 AC_OUTPUT

--- a/m4/hts_prog_cc_warnings.m4
+++ b/m4/hts_prog_cc_warnings.m4
@@ -1,0 +1,208 @@
+dnl @synopsis HTS_PROG_CC_WARNINGS([ANSI])
+dnl
+dnl Derived from
+dnl     http://ac-archive.sourceforge.net/ac-archive/vl_prog_cc_warnings.html
+dnl
+dnl Enables a reasonable set of warnings for the C compiler.
+dnl Optionally, if the first argument is nonempty, turns on flags which
+dnl enforce and/or enable proper ANSI C if such are known with the
+dnl compiler used.
+dnl
+dnl Currently this macro knows about GCC, Solaris C compiler, Digital
+dnl Unix C compiler, C for AIX Compiler, HP-UX C compiler, IRIX C
+dnl compiler, NEC SX-5 (Super-UX 10) C compiler, and Cray J90 (Unicos
+dnl 10.0.0.8) C compiler.
+dnl
+dnl @category C
+dnl @author Ville Laurikari <vl@iki.fi>
+dnl Updated by Rob Davies <rmd@sanger.ac.uk> for HTSlib
+dnl @license AllPermissive
+dnl Copying and distribution of this file, with or without modification,
+dnl are permitted in any medium without royalty provided the copyright notice
+dnl and this notice are preserved. Users of this software should generally
+dnl follow the principles of the MIT License including its disclaimer.
+dnl Original Copyright (c) Ville Laurikari 2002
+dnl Modifications Copyright (c) Genome Research Limited 2015,2017
+
+AC_DEFUN([HTS_PROG_CC_WARNINGS], [
+  AC_ARG_ENABLE([warnings],
+    [AS_HELP_STRING([--disable-warnings], [turn off compiler warnings])],
+    [],
+    [enable_warnings=yes])
+
+  AS_IF([test "x$enable_warnings" != xno],[
+    AC_REQUIRE([AC_PROG_GREP])
+
+    ansi="$1"
+    AS_IF([test "x$ansi" = "x"],
+          [msg="for C compiler warning flags"],
+          [msg="for C compiler warning and ANSI conformance flags"])
+
+    AC_MSG_CHECKING($msg)
+    AC_CACHE_VAL(hts_cv_prog_cc_warnings, [dnl
+      hts_cv_prog_cc_warnings=""
+      AS_IF([test "x$CC" != "x"],[
+        cat > conftest.c <<EOF
+int main(int argc, char **argv) { return 0; }
+EOF
+
+dnl Most compilers print some kind of a version string with some command
+dnl line options (often "-V").  The version string should be checked
+dnl before doing a test compilation run with compiler-specific flags.
+dnl This is because some compilers (like the Cray compiler) only
+dnl produce a warning message for unknown flags instead of returning
+dnl an error, resulting in a false positive.  Also, compilers may do
+dnl erratic things when invoked with flags meant for a different
+dnl compiler.
+
+dnl We attempt to strip out any flags that are already on CFLAGS.
+dnl If an option needs more than one word (e.g. see Cray below) then
+dnl they should be separated by hash signs (#), which will be converted
+dnl to spaces before comparing and possibly adding to CFLAGS.
+dnl This separator will need to be changed if a new compiler ever needs
+dnl an option that includes a hash sign...
+
+        # Tests for flags to enable C compiler warnings
+        # GCC compatible
+        AS_IF([test "x$GCC" = "xyes" &&
+               "$CC" -c -Wall conftest.c > /dev/null 2>&1 &&
+               test -f conftest.o],[dnl
+          AS_IF([test "x$ansi" = "x"],
+                [hts_cv_prog_cc_warnings="-Wall"],
+                [hts_cv_prog_cc_warnings="-Wall -ansi -pedantic"])
+        ],
+        # Sun Studio or Solaris C compiler
+        ["$CC" -V 2>&1 | $GREP -i -E "WorkShop|Sun C" > /dev/null 2>&1 &&
+         "$CC" -c -v -Xc conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o],[dnl
+        AS_IF([test "x$ansi" = "x"],
+              [hts_cv_prog_cc_warnings="-v"],
+              [hts_cv_prog_cc_warnings="-v -Xc"])
+        ],
+        # Digital Unix C compiler
+        ["$CC" -V 2>&1 | $GREP -i "Digital UNIX Compiler" > /dev/null 2>&1 &&
+         "$CC" -c -verbose -w0 -warnprotos -std1 conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o], [dnl
+           AS_IF([test "x$ansi" = "x"],
+                 [hts_cv_prog_cc_warnings="-verbose -w0 -warnprotos"],
+                 [hts_cv_prog_cc_warnings="-verbose -w0 -warnprotos -std1"])
+           ],
+        # C for AIX Compiler
+        ["$CC" 2>&1 | $GREP -i "C for AIX Compiler" > /dev/null 2>&1 &&
+         "$CC" -c -qlanglvl=ansi -qinfo=all conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o],[dnl
+        AS_IF([test "x$ansi" = "x"],
+              [hts_cv_prog_cc_warnings="-qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd"],
+              [hts_cv_prog_cc_warnings="-qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd -qlanglvl=ansi"])
+        ],
+        # IRIX C compiler
+        ["$CC" -version 2>&1 | $GREP -i "MIPSpro Compilers" > /dev/null 2>&1 &&
+         "$CC" -c -fullwarn -ansi -ansiE conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o],[dnl
+           AS_IF([test "x$ansi" = "x"],
+                 [hts_cv_prog_cc_warnings="-fullwarn"],
+                 [hts_cv_prog_cc_warnings="-fullwarn -ansi -ansiE"])
+          ],
+        # HP-UX C compiler
+        [what "$CC" 2>&1 | $GREP -i "HP C Compiler" > /dev/null 2>&1 &&
+         "$CC" -c -Aa +w1 conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o],[dnl
+        AS_IF([test "x$ansi" = "x"],
+              [hts_cv_prog_cc_warnings="+w1"],
+              [hts_cv_prog_cc_warnings="+w1 -Aa"])
+        ],
+        # The NEC SX series (Super-UX 10) C compiler
+        ["$CC" -V 2>&1 | $GREP "/SX" > /dev/null 2>&1 &&
+         "$CC" -c -pvctl[,]fullmsg -Xc conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o],[
+        AS_IF([test "x$ansi" = "x"],
+              [hts_cv_prog_cc_warnings="-pvctl[,]fullmsg"],
+              [hts_cv_prog_cc_warnings="-pvctl[,]fullmsg -Xc"])
+        ],
+        # The Cray C compiler (Unicos)
+        ["$CC" -V 2>&1 | $GREP -i "Cray" > /dev/null 2>&1 &&
+         "$CC" -c -h msglevel_2 conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o],[dnl
+        AS_IF([test "x$ansi" = "x"],
+              [hts_cv_prog_cc_warnings="-h#msglevel_2"],
+              [hts_cv_prog_cc_warnings="-h#msglevel_2,conform"])
+        ],
+	# The Tiny C Compiler
+        ["$CC" -v 2>&1 | $GREP "tcc version" > /dev/null &&
+         "$CC" -Wall -c conftest.c > /dev/null 2>&1 &&
+         test -f conftest.o],[dnl
+         hts_cv_prog_cc_warnings="-Wall"
+        ])
+        rm -f conftest.*
+      ])
+    ])
+
+    AS_IF([test "x$hts_cv_prog_cc_warnings" != "x"],[
+dnl Print result, with underscores as spaces
+ac_arg_result=`echo "$hts_cv_prog_cc_warnings" | tr '#' ' '`
+AC_MSG_RESULT($ac_arg_result)
+
+dnl Add options to CFLAGS only if they are not already present
+ac_arg_needed=""
+for ac_arg in $hts_cv_prog_cc_warnings
+do
+  ac_arg_sp=`echo "$ac_arg" | tr '#' ' '`
+  AS_CASE([" $CFLAGS "],
+[*" $ac_arg_sp "*], [],
+[ac_arg_needed="$ac_arg_all $ac_arg_sp"])
+done
+CFLAGS="$ac_arg_needed $CFLAGS"],[dnl
+      AC_MSG_RESULT(unknown)
+    ])
+  ])
+])dnl HTS_PROG_CC_WARNINGS
+
+# SYNOPSIS
+#
+# HTS_PROG_CC_WERROR(FLAGS_VAR)
+#
+# Set FLAGS_VAR to the flags needed to make the C compiler treat warnings
+# as errors.
+
+AC_DEFUN([HTS_PROG_CC_WERROR], [
+  AC_ARG_ENABLE([werror],
+    [AS_HELP_STRING([--enable-werror], [change warnings into errors, where supported])],
+    [enable_werror=yes],
+    [])
+
+  AS_IF([test "x$enable_werror" = xyes],[
+    AC_MSG_CHECKING([for C compiler flags to error on warnings])
+    AC_CACHE_VAL(hts_cv_prog_cc_werror, [dnl
+      hts_cv_prog_cc_werror=""
+      AS_IF([test "x$CC" != "x"],[
+        cat > conftest.c <<EOF
+int main(int argc, char **argv) { return 0; }
+EOF
+
+        AS_IF(dnl
+	 # Tests for flags to make the C compiler treat warnings as errors
+         # GCC compatible
+         [test "x$GCC" = "xyes" &&
+          "$CC" -c -Werror conftest.c > /dev/null 2>&1 &&
+          test -f conftest.o],[hts_cv_prog_cc_werror="-Werror"],
+         # Sun Studio or Solaris C compiler
+         ["$CC" -V 2>&1 | $GREP -i -E "WorkShop|Sun C" > /dev/null 2>&1 &&
+          "$CC" -c -errwarn=%all conftest.c > /dev/null 2>&1 &&
+          test -f conftest.o],[hts_cv_prog_cc_werror="-errwarn=%all"],
+	 # The Tiny C Compiler
+         ["$CC" -v 2>&1 | $GREP "tcc version" > /dev/null &&
+          "$CC" -Wall -c conftest.c > /dev/null 2>&1 &&
+          test -f conftest.o],[hts_cv_prog_cc_werror="-Werror"]
+         dnl TODO: Add more compilers
+        )
+        rm -f conftest.*
+      ])
+    ])
+    AS_IF([test "x$hts_cv_prog_cc_werror" != x],[
+      AC_MSG_RESULT($hts_cv_prog_cc_werror)
+      AS_IF([test "x$1" != x],[eval AS_TR_SH([$1])="$hts_cv_prog_cc_werror"])
+    ],[dnl
+      AC_MSG_RESULT(unknown)
+    ])
+  ])
+])dnl HTS_PROG_CC_WERROR

--- a/m4/hts_prog_cc_warnings.m4
+++ b/m4/hts_prog_cc_warnings.m4
@@ -166,11 +166,11 @@ CFLAGS="$ac_arg_needed $CFLAGS"],[dnl
 
 AC_DEFUN([HTS_PROG_CC_WERROR], [
   AC_ARG_ENABLE([werror],
-    [AS_HELP_STRING([--enable-werror], [change warnings into errors, where supported])],
-    [enable_werror=yes],
-    [])
+    [AS_HELP_STRING([--disable-werror], [do not try to change warnings into errors])],
+    [],
+    [enable_werror=yes])
 
-  AS_IF([test "x$enable_werror" = xyes],[
+  AS_IF([test "x$enable_werror" != xno],[
     AC_MSG_CHECKING([for C compiler flags to error on warnings])
     AC_CACHE_VAL(hts_cv_prog_cc_werror, [dnl
       hts_cv_prog_cc_werror=""

--- a/src/bambi.c
+++ b/src/bambi.c
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "htslib/hts.h"
 #include "bambi.h"
+#include "bambi_utils.h"
 
 int main_decode(int argc, char *argv[]);
 int main_i2b(int argc, char *argv[]);
@@ -39,38 +40,6 @@ int main_spatial_filter(int argc, char *argv[]);
 const char *bambi_version()
 {
     return VERSION;
-}
-
-void display(const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
-  vfprintf(stderr, fmt, ap);
-  va_end(ap);
-}
-
-void die(const char *fmt, ...)
-{
-    va_list ap;
-    va_start(ap,fmt);
-    fflush(stdout);
-    vfprintf(stderr, fmt, ap);
-    va_end(ap);
-    fflush(stderr);
-    exit(EXIT_FAILURE);
-}
-
-void * _s_malloc(size_t size, const char *file, unsigned int line, const char *func)
-{
-    void *m = malloc(size);
-    if (!m) die("Couldn't allocate %zd bytes in %s at %s line %u: %s\n", size, func, file, line, strerror(errno));
-    return m;
-}
-
-void * _s_realloc(void *ptr, size_t size, const char *file, unsigned int line, const char *func)
-{
-    void *m = realloc(ptr, size);
-    if (!m) die("Couldn't reallocate %zd bytes in %s at %s line %u: %s\n", size, func, file, line, strerror(errno));
-    return m;
 }
 
 static void usage(FILE *fp)

--- a/src/bambi_utils.c
+++ b/src/bambi_utils.c
@@ -1,0 +1,58 @@
+/*  bambi_utils.c -- bambi utility functions
+
+    Copyright (C) 2016 Genome Research Ltd.
+
+    Author: Jennifer Liddle <js10@sanger.ac.uk>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+
+void display(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vfprintf(stderr, fmt, ap);
+  va_end(ap);
+}
+
+void die(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap,fmt);
+    fflush(stdout);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fflush(stderr);
+    exit(EXIT_FAILURE);
+}
+
+void * _s_malloc(size_t size, const char *file, unsigned int line, const char *func)
+{
+    void *m = malloc(size);
+    if (!m) die("Couldn't allocate %zd bytes in %s at %s line %u: %s\n", size, func, file, line, strerror(errno));
+    return m;
+}
+
+void * _s_realloc(void *ptr, size_t size, const char *file, unsigned int line, const char *func)
+{
+    void *m = realloc(ptr, size);
+    if (!m) die("Couldn't reallocate %zd bytes in %s at %s line %u: %s\n", size, func, file, line, strerror(errno));
+    return m;
+}

--- a/src/bambi_utils.h
+++ b/src/bambi_utils.h
@@ -1,4 +1,4 @@
-/* bambi.h
+/* bambi_utils.h
 
     Copyright (C) 2016 Genome Research Ltd.
 
@@ -18,26 +18,16 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __BAMBI_H__
-#define __BAMBI_H__
+#ifndef BAMBI_UTILS_H
+#define BAMBI_UTILS_H
 
-#include "config.h"
-#include "hts_addendum.h"
-#include "array.h"
-#include "bambi_utils.h"
+void display(const char *fmt, ...);
+void die(const char *fmt, ...);
 
-#define INDEX_SEPARATOR "-"
-#define QUAL_SEPARATOR " "
+#define smalloc(s) _s_malloc((s), __FILE__, __LINE__, __func__)
+#define srealloc(p, s) _s_realloc((p), (s), __FILE__, __LINE__, __func__)
+void * _s_malloc(size_t size, const char *file, unsigned int line, const char *func);
+void * _s_realloc(void *ptr, size_t size, const char *file, unsigned int line, const char *func);
 
-// Machine Type is used by i2b 
-typedef enum { MT_UNKNOWN,
-               MT_MISEQ,           // MiSeq and HiSeq 2000/2500
-               MT_NEXTSEQ,         // MiniSeq and NextSeq 500/550
-               MT_HISEQX,          // HiSeq X and HiSeq 3000/4000
-               MT_NOVASEQ          // NovaSeq
-             } MACHINE_TYPE;
-
-const char *bambi_version(void);
 
 #endif
-

--- a/src/chrsplit.c
+++ b/src/chrsplit.c
@@ -36,6 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "array.h"
 #include "bamit.h"
+#include "parse.h"
 
 char *strptime(const char *s, const char *format, struct tm *tm);
 
@@ -340,7 +341,7 @@ static int processFiles(BAMit_t *in_bam, BAMit_t *target_bam, BAMit_t *exclude_b
             bam1_t *rec = recordSet->entries[n];
             if (!(rec->core.flag & BAM_FUNMAP)) {
                 bool notfound = (find_in_subset(opts->subset,getReferenceName(rec,in_bam->h))==-1);
-                if (( opts->invert) ^ (find_in_subset(opts->subset,getReferenceName(rec,in_bam->h))==-1))
+                if (opts->invert ^ notfound)
                 {
                     outBam = exclude_bam;
                     break;

--- a/src/decode.c
+++ b/src/decode.c
@@ -707,7 +707,7 @@ static int countMismatches(char *tag, char *barcode, int maxval)
  */
 static bc_details_t *check_tag_hopping(char *barcode, va_t *barcodeArray, HashTable *tagHopHash, opts_t *opts)
 {
-    bc_details_t *bcd=NULL, *best_match1, *best_match2;
+    bc_details_t *bcd = NULL, *best_match1 = NULL, *best_match2 = NULL;
     char stack_idx1[STACK_BC_LEN], stack_idx2[STACK_BC_LEN];
     char *idx1 = stack_idx1, *idx2 = stack_idx2;
     int nmBest1 = opts->idx1_len + opts->idx2_len + 1;
@@ -746,6 +746,8 @@ static bc_details_t *check_tag_hopping(char *barcode, va_t *barcodeArray, HashTa
         HashItem *hi;
         char stack_key[STACK_BC_LEN];
         char *key = stack_key;
+
+        assert(best_match1 != NULL && best_match2 != NULL);
         if (opts->idx1_len + opts->idx2_len + 2 >= sizeof(stack_key)) {
             key = malloc(opts->idx1_len + opts->idx2_len + 2);
             if (!key) die("Out of memory");
@@ -913,6 +915,7 @@ static void add_suffix(bam1_t *rec, char *suffix)
  */
 static void addNewRG(SAM_hdr *sh, char *entry, char *bcname, char *lib, char *sample, char *desc)
 {
+    assert(entry != NULL);
     char *saveptr;
     char *p = strtok_r(entry,"\t",&saveptr);
     char *newtag = malloc(strlen(p)+1+strlen(bcname)+1);

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -323,8 +323,9 @@ static void HashItemDestroy(HashTable *h, HashItem *hi, int deallocate_data) {
 	if (hi->key)
 	    free(hi->key);
 
-    if (deallocate_data && hi->data.p)
-	free(hi->data.p);
+    if (deallocate_data && hi->data.p) {
+        free(hi->data.p);
+    }
 
 	free(hi);
 

--- a/src/i2b.c
+++ b/src/i2b.c
@@ -897,6 +897,7 @@ static ia_t *getTileList(opts_t *opts)
             for (int n=0; n < ptr->nodesetval->nodeNr; n++) {
                 char *t = (char *)ptr->nodesetval->nodeTab[n]->children->content;
                 char *saveptr;
+                assert(t != NULL);
                 char *lane = strtok_r(t, "_", &saveptr);
                 char *tileno = strtok_r(NULL, "_", &saveptr);
                 if (lane && tileno) {
@@ -984,7 +985,7 @@ static ia_t *getTileList(opts_t *opts)
 static char *getCycleName(int readCount, bool isIndex)
 {
     // implements naming convention used by Illumina2Bam
-    char *cycleName = calloc(1,16);
+    char *cycleName = calloc(1,20);
 ;
     if (isIndex) {
         if (readCount==1) { strcpy(cycleName,"readIndex"); }

--- a/src/read2tags.c
+++ b/src/read2tags.c
@@ -37,6 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "array.h"
 #include "bamit.h"
+#include "parse.h"
 
 #define DEFAULT_KEEP_TAGS "BC,QT,RG"
 #define DEFAULT_DISCARD_TAGS "as,af,aa,a3,ah"
@@ -358,7 +359,7 @@ static char *get_read(bam1_t *rec)
 {
     int len = rec->core.l_qseq + 1;
     char *read = calloc(1, kroundup32(len));
-    char *seq = bam_get_seq(rec);
+    uint8_t *seq = bam_get_seq(rec);
     int n;
 
     for (n=0; n < rec->core.l_qseq; n++) {
@@ -373,7 +374,7 @@ static char *get_read(bam1_t *rec)
 static char *get_quality(bam1_t *rec)
 {
     char *quality = calloc(1, rec->core.l_qseq + 1);
-    char *q = bam_get_qual(rec);
+    uint8_t *q = bam_get_qual(rec);
     int n;
 
     for (n=0; n < rec->core.l_qseq; n++) {
@@ -420,7 +421,7 @@ static bam1_t *make_new_rec(bam1_t *rec, char *seq, char *qual)
     int new_len = (newrec->core.l_qseq+1)/2 + newrec->core.l_qseq;
     newrec->l_data = newrec->l_data - old_len + new_len;
 ;
-    char *cp = bam_get_seq(newrec);
+    uint8_t *cp = bam_get_seq(newrec);
     int i;
     for (i = 0; i+1 < newrec->core.l_qseq; i+=2) {
         *cp++ = (L[(uc)seq[i]]<<4) + L[(uc)seq[i+1]];
@@ -488,11 +489,11 @@ static void add_or_update(va_t *va, char *tag, char *data)
  */
 static void add_tag(bam1_t *rec, char *tag, char *data, opts_t *opts)
 {
-    char *s = bam_aux_get(rec,tag);
+    uint8_t *s = bam_aux_get(rec,tag);
     if (s) { // tag already exists
         if (opts->replace) {
             bam_aux_del(rec,s);
-            bam_aux_append(rec, tag, 'Z', strlen(data)+1, data);
+            bam_aux_append(rec, tag, 'Z', strlen(data)+1, (uint8_t *) data);
         }
         if (opts->merge) {
             if (*s != 'Z' && *s != 'H') { 
@@ -500,10 +501,15 @@ static void add_tag(bam1_t *rec, char *tag, char *data, opts_t *opts)
                 exit(1);
             }
             char *old_data = bam_aux2Z(s);
-            char *new_data = calloc(1,strlen(old_data)+strlen(data)+1);
-            strcpy(new_data,old_data); strcat(new_data,data);
+            size_t old_len = strlen(old_data);
+            size_t data_len = strlen(data);
+            uint8_t *new_data = malloc(old_len+data_len+1);
+            if (!new_data) die("Out of memory");
+            memcpy(new_data, old_data, old_len);
+            memcpy(new_data + old_len, data, data_len + 1);
             bam_aux_del(rec,s);
-            bam_aux_append(rec, tag, 'Z', strlen(new_data)+1, new_data);
+            bam_aux_append(rec, tag, 'Z', old_len+data_len+1, new_data);
+            free(new_data);
         }
         if (!opts->replace && !opts->merge) {
             fprintf(stderr,"Found duplicate tag [%s] and no --replace or --merge option\n", tag);
@@ -511,7 +517,7 @@ static void add_tag(bam1_t *rec, char *tag, char *data, opts_t *opts)
         }
     } else {
         // add new tag
-        bam_aux_append(rec, tag, 'Z', strlen(data)+1, data);
+        bam_aux_append(rec, tag, 'Z', strlen(data)+1, (uint8_t *) data);
     }
 }
 
@@ -619,7 +625,7 @@ static int invalid_record(bam1_t *rec, int nrec)
 /*
  * return the length of some aux data
  */
-static int aux_type2size(char *s)
+static int aux_type2size(uint8_t *s)
 {
     switch (*s) {
     case 'A': case 'c': case 'C':
@@ -631,7 +637,7 @@ static int aux_type2size(char *s)
     case 'd':
         return 8;
     case 'Z': case 'H': case 'B':
-        return strlen(s+1) + 1;
+        return strlen((char *) s+1) + 1;
     default:
         return 0;
     }
@@ -675,21 +681,26 @@ static bam1_t *merge_records(bam1_t *r1, bam1_t *r2, opts_t *opts)
                 if (opts->merge) {
                     // merge with existing tag
                     if (type == 'Z' || type == 'H') {
-                        char *t = bam_aux_get(dst,tag);
-                        char *data = calloc(1, strlen(s) + strlen(t+1) + 1);
-                        strcat(data,t+1); strcat(data,s);
+                        uint8_t *t = bam_aux_get(dst,tag);
+                        size_t t_len = strlen((char *) t + 1);
+                        size_t s_len = strlen((char *) s);
+                        uint8_t *data = malloc(t_len + s_len + 1);
+                        if (!data) die("Out of memory");
+                        memcpy(data, t + 1, t_len);
+                        memcpy(data + t_len, s, s_len + 1);
                         bam_aux_del(dst,t);
-                        bam_aux_append(dst,tag,type,strlen(data)+1,data);
+                        bam_aux_append(dst,tag,type,t_len + s_len + 1,data);
+                        free(data);
                     }
                 }
                 if (opts->replace) {
                     // replace existing tag
-                    char *t = bam_aux_get(dst,tag);
+                    uint8_t *t = bam_aux_get(dst,tag);
                     bam_aux_del(dst,t);
                     bam_aux_append(dst,tag,type,len,s);
                 }
                 if (!opts->merge && !opts->replace) {
-                    char *t = bam_aux_get(dst,tag);
+                    uint8_t *t = bam_aux_get(dst,tag);
                     if (bam_aux_cmp(s-1,t)) {
                         fprintf(stderr,"Tag [%s] already exists and is not the same value\n", tag);
                         exit(1);

--- a/src/select.c
+++ b/src/select.c
@@ -36,11 +36,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "array.h"
 #include "bamit.h"
+#include "parse.h"
 
 char *strptime(const char *s, const char *format, struct tm *tm);
 
-static void closeSamFile(void *f) { hts_close((samFile *)f); }
-static void freeBamHdr(void *h) { if (h) bam_hdr_destroy((bam_hdr_t *)h); h=NULL; }
+// static void closeSamFile(void *f) { hts_close((samFile *)f); }
+// static void freeBamHdr(void *h) { if (h) bam_hdr_destroy((bam_hdr_t *)h); h=NULL; }
 static void freeRecord(void *r) { bam_destroy1((bam1_t *)r); }
 static void freeRecordSet(void *s) { va_free((va_t *)s); }
 static void freeChimera(void *s) { ia_free((ia_t *)s); }
@@ -574,7 +575,6 @@ static void checkNextReadsForChimera(va_t *recordSetList, metrics_t *metrics)
 static int processFiles(va_t *in_bit, va_t *out_bit, BAMit_t *unaligned_bam, opts_t *opts)
 {
     BAMit_t *outBam;
-    BAMit_t *bit;
     metrics_t *metrics = metrics_init(in_bit->end);
     int n;
 

--- a/src/spatial_filter.c
+++ b/src/spatial_filter.c
@@ -162,12 +162,12 @@ static HashTable *readSnpFile(opts_t *opts)
     if (snp_hash) die("ERROR: creating snp hash table\n");
 
     while (fgets(line, line_size, fp)) {
-        char key[100];
+        char key[128];
         HashData hd;
         int bin, start, end;
         char chrom[100];
 
-        if (4 != sscanf(line, "%d\t%s\t%d\t%d", &bin, chrom, &start, &end)) {
+        if (4 != sscanf(line, "%d\t%99s\t%d\t%d", &bin, chrom, &start, &end)) {
             die("ERROR: reading snp file\n%s\n", line);
         }
 
@@ -1009,7 +1009,6 @@ static int findRegion(opts_t *s, RegionTable ***rts, int ntiles, int x, int y)
     int ix = x2region(x, s->region_size);
     int iy = x2region(y, s->region_size);
     char key[100];
-    char *cp;
     HashItem *hi;
 
     makeRegionKey(key, ix, iy);
@@ -1244,7 +1243,6 @@ static RegionTable ***makeRegionTable(opts_t *s, BAMit_t *fp_bam, int *bam_ntile
  */
 static int filter_bam(opts_t *s, BAMit_t *fp_in_bam, BAMit_t *fp_out_bam)
 {
-	int lane = -1;
     char *rgid;
 	bam1_t *bam;
     bool ignore = false;
@@ -1427,11 +1425,8 @@ static void applyFilter(opts_t *s)
 	BAMit_t *fp_input_bam;
 	BAMit_t *fp_output_bam;
 	FILE *apply_stats_fd = NULL;
-	char out_mode[5] = "wb";
 	char *out_bam_file = NULL;
 	char *apply_stats_file = NULL;
-	FILE *fp;
-    int read;
 
     openFilters(s->filters,s->rgids);
 

--- a/test/t_chrsplit.c
+++ b/test/t_chrsplit.c
@@ -97,7 +97,6 @@ static void testxahuman(char *TMPDIR)
     char** argv;
     char target[512];
     char exclude[512];
-    char cmd[512];
     va_t *expected_target = va_init(10,free);
     va_t *expected_exclude = va_init(10,free);
 
@@ -140,7 +139,6 @@ static void testxahuman_exclude_unaligned(char *TMPDIR)
     char** argv;
     char target[512];
     char exclude[512];
-    char cmd[512];
     va_t *expected_target = va_init(10,free);
     va_t *expected_exclude = va_init(10,free);
 
@@ -184,7 +182,6 @@ static void testyhuman(char *TMPDIR)
     char** argv;
     char target[512];
     char exclude[512];
-    char cmd[512];
     va_t *expected_target = va_init(10,free);
     va_t *expected_exclude = va_init(10,free);
 
@@ -255,6 +252,7 @@ int main(int argc, char**argv)
 
     testxahuman(TMPDIR);
     testxahuman_exclude_unaligned(TMPDIR);
+    testyhuman(TMPDIR);
 
     printf("chrsplit tests: %s\n", failure ? "FAILED" : "Passed");
     return failure ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/test/t_posfile.c
+++ b/test/t_posfile.c
@@ -61,8 +61,6 @@ void icheckEqual(char *name, int expected, int actual)
 
 int main(int argc, char**argv)
 {
-    int n;
-
     posfile_t *posfile;
 
     /*

--- a/test/t_read2tags.c
+++ b/test/t_read2tags.c
@@ -289,9 +289,6 @@ int main(int argc, char**argv)
     int argc_1;
     char** argv_1;
     char outputfile[1024];
-    char unalignedfile[512];
-    char metricsfile[512];
-    char cmd[512];
 
     // minimal options
     sprintf(outputfile,"%s/read2tags_1.bam", TMPDIR);

--- a/test/t_select.c
+++ b/test/t_select.c
@@ -197,7 +197,6 @@ int main(int argc, char**argv)
     char outputfile[1024];
     char unalignedfile[512];
     char metricsfile[512];
-    char cmd[512];
 
     sprintf(outputfile,"%s/select_1.bam,%s/select_1_human.bam", TMPDIR, TMPDIR);
     sprintf(metricsfile,"%s/select_1_metrics.json", TMPDIR);

--- a/test/t_sf.c
+++ b/test/t_sf.c
@@ -103,36 +103,36 @@ int main(int argc, char**argv)
     // minimal options
     char outputfile[512];
     char filterfile[512];
-    char cmd[1024];
+    char cmd[2048];
     char prog[512];
 
     sprintf(prog, "%s", "src/bambi spatial_filter");
 
     // create filter
     if (verbose) fprintf(stderr,"Creating filter\n");
-    sprintf(filterfile,"%s/sf_1.filter", TMPDIR);
-    sprintf(outputfile,"%s/sf_filtered.bam", TMPDIR);
-    sprintf(cmd, "%s -c -F %s %s", prog, filterfile, MKNAME(DATA_DIR,"/sf.bam"));
+    snprintf(filterfile, sizeof(filterfile), "%s/sf_1.filter", TMPDIR);
+    snprintf(outputfile, sizeof(outputfile), "%s/sf_filtered.bam", TMPDIR);
+    snprintf(cmd, sizeof(cmd), "%s -c -F %s %s", prog, filterfile, MKNAME(DATA_DIR,"/sf.bam"));
     if (system(cmd)) { fprintf(stderr,"Command failed: %s\n",cmd); failure++; }
     checkFilterFiles(prog, TMPDIR, filterfile, MKNAME(DATA_DIR,"/out/sf_1.filter"));
 
     // apply filter
     if (verbose) fprintf(stderr,"Applying filter\n");
-    sprintf(cmd, "%s -a --verbose -F %s -o %s %s", prog, filterfile, outputfile, MKNAME(DATA_DIR,"/sf.bam"));
+    snprintf(cmd, sizeof(cmd), "%s -a --verbose -F %s -o %s %s", prog, filterfile, outputfile, MKNAME(DATA_DIR,"/sf.bam"));
     if (system(cmd)) { fprintf(stderr,"Command failed: %s\n",cmd); failure++; }
     checkFiles(TMPDIR, outputfile, MKNAME(DATA_DIR,"/out/sf_filtered.bam"), verbose);
 
     // multiple filters
     if (verbose) fprintf(stderr,"Multiple filters\n");
-    sprintf(outputfile,"%s/sf_filtered.bam", TMPDIR);
-    sprintf(cmd,"%s -a -v -f -F %s,%s,%s --rg 25077_3#3,25077_4#3,25077_5#3 -o %s %s", prog, MKNAME(DATA_DIR,"/sf_1.filter"), MKNAME(DATA_DIR,"/sf_2.filter"), MKNAME(DATA_DIR,"/sf_3.filter"), outputfile, MKNAME(DATA_DIR,"/sf2.bam"));
+    snprintf(outputfile, sizeof(outputfile), "%s/sf_filtered.bam", TMPDIR);
+    snprintf(cmd, sizeof(cmd), "%s -a -v -f -F %s,%s,%s --rg 25077_3#3,25077_4#3,25077_5#3 -o %s %s", prog, MKNAME(DATA_DIR,"/sf_1.filter"), MKNAME(DATA_DIR,"/sf_2.filter"), MKNAME(DATA_DIR,"/sf_3.filter"), outputfile, MKNAME(DATA_DIR,"/sf2.bam"));
     if (system(cmd)) { fprintf(stderr,"Command failed: %s\n",cmd); failure++; }
     checkFiles(TMPDIR, outputfile, MKNAME(DATA_DIR,"/out/sf2.bam"), verbose);
 
     // missing filters
     if (verbose) fprintf(stderr,"Missing filters\n");
-    sprintf(outputfile,"%s/sf_filtered_2.bam", TMPDIR);
-    sprintf(cmd,"%s -a -v -f -F %s,%s,%s --rg 25077_3#3,25077_4#3,25077_5#x -o %s %s", prog, MKNAME(DATA_DIR,"/sf_1.filter"), MKNAME(DATA_DIR,"/sf_2.filter"), MKNAME(DATA_DIR,"/sf_3.filter"), outputfile, MKNAME(DATA_DIR,"/sf2.bam"));
+    snprintf(outputfile, sizeof(outputfile), "%s/sf_filtered_2.bam", TMPDIR);
+    snprintf(cmd, sizeof(cmd), "%s -a -v -f -F %s,%s,%s --rg 25077_3#3,25077_4#3,25077_5#x -o %s %s", prog, MKNAME(DATA_DIR,"/sf_1.filter"), MKNAME(DATA_DIR,"/sf_2.filter"), MKNAME(DATA_DIR,"/sf_3.filter"), outputfile, MKNAME(DATA_DIR,"/sf2.bam"));
     if (system(cmd)) { fprintf(stderr,"Command failed: %s\n",cmd); failure++; }
     checkFiles(TMPDIR, outputfile, MKNAME(DATA_DIR,"/out/sf_filtered_2.bam"), verbose);
 


### PR DESCRIPTION
Steal HTSlib's hts_prog_cc_warnings so that -Wall gets turned on.

Fix warnings found by gcc 8.1.0. Makes bambi compile cleanly with `gcc-8.1.0 -Wall -Werror` at optimisation levels `-g`, `-g -O2` and `-g -O3`.

Move functions `display()`, `die()`, `smalloc()`, `srealloc()` from bambi.c to new file bambi_utils.c.  Allows them to be used by test programs without also pulling in bambi's own `main()` function.
    
Remove lots of unused variables and a couple of unused functions. Turn on previously unused t_chrsplit `testyhuman()` test.

Deal with various pointer signedness issues, mainly `uint8_t *` / `char *`.
    
Make rts.c `readHeader()` check that `fgets()` actually worked.

Grow some fixed size buffers that might not be big enough.

The last commit turns `-Werror` on by default.
