### PR TITLE
Add AM_PROG_CC_C_O for Automake <1.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT([bambi], m4_esyscmd_s([git describe --dirty --always --tags]), [js10@san
 AC_CONFIG_MACRO_DIR([m4])
 AC_ARG_VAR(HTSDIR,Directory to look for hts)
 AM_INIT_AUTOMAKE([subdir-objects foreign tar-pax no-dependencies])
+AM_PROG_CC_C_O
 
 AC_PROG_CC
 dnl Turn on compiler warnings, if possible


### PR DESCRIPTION
Add AM_PROG_CC_C_O for Automake <1.14 (e.g. RHEL 7.5)