### PR TITLE
Change stats_nreads from 'int' to 'uint64_t'

### DIFF
--- a/src/rts.c
+++ b/src/rts.c
@@ -45,9 +45,9 @@ inline int getHdrReadLength(int read) { return _hdr->readLength[read]; }
 inline int getHdrnregions(void) { return _hdr->nregions; }
 
 inline int getHdrngood_tiles(void) { return _hdr->ngood_tiles; }
-inline int getHdrStatsnreads(void) { return _hdr->stats_nreads; }
+inline uint64_t getHdrStatsnreads(void) { return _hdr->stats_nreads; }
 inline void incHdrStatsnreads(void) { _hdr->stats_nreads++; }
-inline int getHdrStatsnfiltered(void) { return _hdr->stats_nfiltered; }
+inline uint64_t getHdrStatsnfiltered(void) { return _hdr->stats_nfiltered; }
 inline void incHdrStatsnfiltered(void) { _hdr->stats_nfiltered++; }
 inline char *getHdrrgid(void) { return _hdr->rgid; }
 

--- a/src/rts.h
+++ b/src/rts.h
@@ -61,8 +61,8 @@ typedef struct {
     char *comments[N_COMMENTS];
     char *filterData;
     char *rgid;             // used as a key in the hash table
-    int stats_nreads;       // number of records read
-    int stats_nfiltered;    // number of records filtered out
+    uint64_t stats_nreads;       // number of records read
+    uint64_t stats_nfiltered;    // number of records filtered out
 } Header;
 
 // An internal structure used to create the filter file
@@ -90,9 +90,9 @@ int xy2region(int x, int y);
 int getHdrngood_tiles(void);
 int getHdrReadLength(int read);
 int getHdrnregions(void);
-int getHdrStatsnreads(void);
+uint64_t getHdrStatsnreads(void);
 void incHdrStatsnreads(void);
-int getHdrStatsnfiltered(void);
+uint64_t getHdrStatsnfiltered(void);
 void incHdrStatsnfiltered(void);
 char *getHdrrgid(void);
 va_t *HdrHash2Array(void);

--- a/src/spatial_filter.c
+++ b/src/spatial_filter.c
@@ -1505,8 +1505,8 @@ static void applyFilter(opts_t *s)
     for (int n=0; n < va->end; n++) {
         Header *hdr = (Header *)va->entries[n];
         fprintf(apply_stats_fd, "%s\t", (strcmp(hdr->rgid,"null") ? hdr->rgid : "Total"));
-        fprintf(apply_stats_fd, "Processed %d \t", hdr->stats_nreads);
-        fprintf(apply_stats_fd, "%s %d traces\n", (s->qcfail ? "Failed" : "Removed"), hdr->stats_nfiltered);
+        fprintf(apply_stats_fd, "Processed %" PRIu64 " \t", hdr->stats_nreads);
+        fprintf(apply_stats_fd, "%s %" PRIu64 " traces\n", (s->qcfail ? "Failed" : "Removed"), hdr->stats_nfiltered);
     }
     fprintf(apply_stats_fd, "\n");
 


### PR DESCRIPTION
To avoid integer overflow in the metrics report.