### PR TITLE
Increase buffer size when reading barcode file

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -709,8 +709,8 @@ va_t *loadBarcodeFile(decode_opts_t *opts)
         return NULL;
     }
     
-    char buf[256];
-    size_t n = 256;
+    char buf[8192];
+    size_t n = 8192;
     lineno++;
     if (0 >= hgets(buf,n,fh)) {    // burn first line which is a header
         fprintf(stderr,"ERROR: problem reading barcode file\n");


### PR DESCRIPTION
This is a temporary fix. We really need to check if the line has been read completely. The only obvious way to do this is to see if the last character in the buffer is a '/n'