### PR TITLE
Add docker building and publishing to ghcr.io with github actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,59 @@
+name: "Create release"
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l -e -o pipefail {0}
+    env:
+      IMAGE_NAME: bambi
+      REPOSITORY_OWNER: ${{ github.repository_owner }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Fetch Tags"
+        # Workaround for https://github.com/actions/checkout/issues/290
+        run: git fetch --tags --force
+
+      - name: "Get release variables"
+        run: |
+          echo 'RELEASE_VERSION='$(git describe --always --tags --dirty) >> $GITHUB_ENV
+          echo 'GIT_URL='$(git remote get-url origin) >> $GITHUB_ENV
+          echo 'GIT_COMMIT='$(git log --pretty=format:'%H' -n 1) >> $GITHUB_ENV
+
+      - name: "Login to Docker registry"
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Build Docker image"
+        run: |
+          set -x
+          docker build --rm \
+            --file docker/Dockerfile \
+            --build-arg HTSLIB_BRANCH=1.18 \
+            --platform linux/amd64 \
+            --progress plain \
+            --load \
+            --label "uk.ac.sanger.repository=$GIT_URL" \
+            --label "uk.ac.sanger.commit=$GIT_COMMIT" \
+            --tag "ghcr.io/$REPOSITORY_OWNER/$IMAGE_NAME:$RELEASE_VERSION" \
+            --tag "ghcr.io/$REPOSITORY_OWNER/$IMAGE_NAME:latest" \
+            .
+
+      - name: "Push image to registry"
+        run: |
+            docker push "ghcr.io/$REPOSITORY_OWNER/$IMAGE_NAME:$RELEASE_VERSION"
+            docker push "ghcr.io/$REPOSITORY_OWNER/$IMAGE_NAME:latest"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,10 +47,13 @@ jobs:
             --platform linux/amd64 \
             --progress plain \
             --load \
-            --label "uk.ac.sanger.repository=$GIT_URL" \
-            --label "uk.ac.sanger.commit=$GIT_COMMIT" \
-            --tag "ghcr.io/$REPOSITORY_OWNER/$IMAGE_NAME:$RELEASE_VERSION" \
-            --tag "ghcr.io/$REPOSITORY_OWNER/$IMAGE_NAME:latest" \
+            --label "org.opencontainers.image.title=bambi" \
+            --label "org.opencontainers.image.source=${GIT_URL}" \
+            --label "org.opencontainers.image.revision=${GIT_COMMIT}" \
+            --label "org.opencontainers.image.version=${RELEASE_VERSION}" \
+            --label "org.opencontainers.image.created=$(date --utc --iso-8601=seconds)" \
+            --tag "ghcr.io/$REPOSITORY_OWNER/${IMAGE_NAME}:${RELEASE_VERSION}" \
+            --tag "ghcr.io/$REPOSITORY_OWNER/${IMAGE_NAME}:latest" \
             .
 
       - name: "Push image to registry"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,6 +26,9 @@ jobs:
         run: git fetch --tags --force
 
       - name: "Get release variables"
+        # RELEASE_VERSION assignment must match the command used in autoconf's
+        # configure.ac file. On update, care should be taken to maintain both
+        # sides congruent.
         run: |
           echo 'RELEASE_VERSION='$(git describe --always --tags --dirty) >> $GITHUB_ENV
           echo 'GIT_URL='$(git remote get-url origin) >> $GITHUB_ENV

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: "Docker"
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  lint-docker:
+    runs-on: ubuntu-latest
+
+    continue-on-error: true
+
+    defaults:
+      run:
+        shell: "bash -l -e -o pipefail {0}"
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Lint Dockerfile"
+        run: |
+          cat <<EOT >> .hadolint.yaml
+          ignored:
+            - DL3008
+          EOT
+          docker run --rm -i -v /"${PWD}"/.hadolint.yaml:/.config/hadolint.yaml ghcr.io/hadolint/hadolint < docker/Dockerfile
+
+  build-docker:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: "bash -l -e -o pipefail {0}"
+
+    steps:
+      - name: "Checkout code"
+        uses: actions /checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Docker build"
+        run: |
+          set -x
+          docker build --rm \
+            --file docker/Dockerfile \
+            --build-arg HTSLIB_BRANCH=1.17 \
+            --tag bambi .
+          docker run bambi bambi --version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,6 @@ jobs:
           set -x
           docker build --rm \
             --file docker/Dockerfile \
-            --build-arg HTSLIB_BRANCH=1.17 \
+            --build-arg HTSLIB_BRANCH=1.18 \
             --tag bambi .
           docker run bambi bambi --version

--- a/.github/workflows/lint-and-test-build-dockerfile.yml
+++ b/.github/workflows/lint-and-test-build-dockerfile.yml
@@ -1,4 +1,4 @@
-name: "Docker"
+name: "lint and test-build Dockerfile"
 
 on:
   push:
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions /checkout@v3
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint-and-test-build-dockerfile.yml
+++ b/.github/workflows/lint-and-test-build-dockerfile.yml
@@ -1,4 +1,4 @@
-name: "lint and test-build Dockerfile"
+name: "Lint and test-build Dockerfile"
 
 on:
   push:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,82 @@
+FROM debian:bookworm AS htslib_build
+
+ARG HTSLIB_BRANCH
+
+# hadolint ignore=DL3003
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    apt-get install -qq -y --no-install-recommends \
+      autoconf \
+      automake \
+      autotools-dev \
+      build-essential \
+      ca-certificates \
+      git \
+      libbz2-dev \
+      libcurl4-openssl-dev \
+      libgd-dev \
+      liblzma-dev \
+      libssl-dev \
+    && \
+    export HTSLIB=/usr/local/src/htslib && \
+    git clone --depth 1 --branch "${HTSLIB_BRANCH}" https://github.com/samtools/htslib.git "${HTSLIB}" && \
+    cd "${HTSLIB}" && \
+    git submodule update --init --recursive && \
+    mkdir -p /tmp/usr/local && autoreconf -i && ./configure --prefix=/tmp/usr/local && make && make install
+
+FROM debian:bookworm AS bambi_build
+
+COPY --from=htslib_build /tmp/usr/local /usr/local
+COPY . /usr/local/src/bambi
+
+WORKDIR /usr/local/src/bambi
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    apt-get install -qq -y --no-install-recommends \
+      autoconf \
+      automake \
+      autotools-dev \
+      build-essential \
+      bzip2 \
+      git \
+      libbz2-dev \
+      libcurl4-openssl-dev \
+      libtool \
+      libgd-dev \
+      liblzma-dev \
+      libxml2-dev \
+      libz-dev \
+      libssl-dev \
+    && \
+    export PREFIX=/tmp/usr/local && \
+    autoreconf -fi && \
+    CPPFLAGS="-I$PREFIX/include" LDFLAGS="-Wl,-rpath,$PREFIX/lib -L$PREFIX/lib" \
+            ./configure --prefix="$PREFIX" --with-htslib="$PREFIX" && \
+    make CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib" && \
+    make install prefix="$PREFIX"
+
+FROM debian:bookworm AS bambi
+
+COPY --from=htslib_build /tmp/usr/local /usr/local
+COPY --from=bambi_build /tmp/usr/local /usr/local
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    apt-get install -qq -y --no-install-recommends \
+      bzip2 \
+      libbz2-dev \
+      libcurl4-openssl-dev \
+      libtool \
+      libgd-dev \
+      liblzma-dev \
+      libxml2-dev \
+      libz-dev \
+      libssl-dev \
+    && \
+    apt-get remove -q -y unattended-upgrades && \
+    apt-get autoremove -q -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,11 @@ RUN apt-get update && \
     git clone --depth 1 --branch "${HTSLIB_BRANCH}" https://github.com/samtools/htslib.git "${HTSLIB}" && \
     cd "${HTSLIB}" && \
     git submodule update --init --recursive && \
-    mkdir -p /tmp/usr/local && autoreconf -i && ./configure --prefix=/tmp/usr/local && make && make install
+    mkdir -p /tmp/usr/local && \
+    autoreconf -i && \
+    ./configure --prefix=/tmp/usr/local && \
+    make && \
+    make install
 
 FROM debian:bookworm AS bambi_build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,10 +64,8 @@ COPY --from=bambi_build /tmp/usr/local /usr/local
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get install -qq -y --no-install-recommends \
-      bzip2 \
       libbz2-1.0 \
       libcurl4 \
-      libtool \
       libgd3 \
       liblzma5 \
       libxml2 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,14 +65,14 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get install -qq -y --no-install-recommends \
       bzip2 \
-      libbz2-dev \
-      libcurl4-openssl-dev \
+      libbz2-1.0 \
+      libcurl4 \
       libtool \
-      libgd-dev \
-      liblzma-dev \
-      libxml2-dev \
-      libz-dev \
-      libssl-dev \
+      libgd3 \
+      liblzma5 \
+      libxml2 \
+      libz1 \
+      libssl3 \
     && \
     apt-get remove -q -y unattended-upgrades && \
     apt-get autoremove -q -y && \


### PR DESCRIPTION
Trying to add container building scaffolding, building and publishing using github actions. Marking as draft because there are some pending things.

- Do we want a docker/README.md with instructions about how to use the container?
- [x] Not clear yet what to do with the manifest. I stole things from irods clients but just to get an idea of what to have there. Placeholder kind of thing.
- [x] Even with some cleaning the container is about 600MB we could try to reduce the thing more
- Not sure what we want for `CMD` and `ENTRYPOINT`. As it is now I'm assuming we will do something like `docker run ghcr.io/wtsi-npg/bambi bambi`. But we should also support check_bcl. Do we want to have an entrypoint script?
- Do we want to have things running with an app user inside the container?
- [x] Do we want to build the container as part of non publishing actions/test (build on all push to branches)? I think it makes things safer because when tagging you are sure the container will build.

The Dockerfile is mostly inspired/stolen from the package build instructions and CI testing.
Linting is not necessary but I like it
The publishing is heavily inspired on [npg-irods-python create-release action](https://github.com/wtsi-npg/npg-irods-python/blob/c489da6f7c2bc8380f8c1ca4eea798c4aecbb5e3/.github/workflows/create-release.yml) 

I have built and published from my fork and it is happy `docker pull ghcr.io/jmtcsngr/bambi` `docker run ghcr.io/jmtcsngr/bambi bambi --version` `docker run ghcr.io/jmtcsngr/bambi check_bcl`